### PR TITLE
Fix user gender migration

### DIFF
--- a/libs/db/pickup-point/drizzle/0002_burly_sphinx.sql
+++ b/libs/db/pickup-point/drizzle/0002_burly_sphinx.sql
@@ -1,2 +1,2 @@
 CREATE TYPE "public"."user_gender" AS ENUM('male', 'female');--> statement-breakpoint
-ALTER TABLE "user" ALTER COLUMN "gender" SET DATA TYPE user_gender;
+ALTER TABLE "user" ALTER COLUMN "gender" SET DATA TYPE user_gender USING gender::user_gender;


### PR DESCRIPTION
To fix error during migrations
```
applying migrations...error: column "gender" cannot be cast automatically to type user_gender
```